### PR TITLE
fix PHP strict warnings (wordpress 4.2.2)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -23,6 +23,7 @@ function form_submit_button($button, $form){
 // Register sidebar
 if ( function_exists('register_sidebar') )
     register_sidebar(array(
+    	'id' => 'sidebar-1',
         'before_widget' => '<div id="%1$s" class="widget %2$s">',
         'after_widget' => '</div>',
         'before_title' => '<h4>',
@@ -46,7 +47,7 @@ if ( ! function_exists( 'bootstrap_setup' ) ):
 		class Bootstrap_Walker_Nav_Menu extends Walker_Nav_Menu {
  
 			
-			function start_lvl( &$output, $depth ) {
+			function start_lvl( &$output, $depth = 0, $args = array() ) {
  
 				$indent = str_repeat( "\t", $depth );
 				$output	   .= "\n$indent<ul class=\"dropdown-menu\">\n";

--- a/header.php
+++ b/header.php
@@ -11,7 +11,7 @@
 		<?php wp_head(); ?>
 	</head>
  
-  <body <?php body_class($class); ?>>
+  <body <?php body_class(isset($class) ? $class : ''); ?>>
     
     <nav class="navbar navbar-default" role="navigation">
       <!-- Brand and toggle get grouped for better mobile display -->


### PR DESCRIPTION
On installing the theme on wordpress 4.2.2 with PHP strict standards enabled, each page has three warnings:

* Notice: register_sidebar was called incorrectly. No id was set in the arguments array for the "Sidebar 1" sidebar. Defaulting to "sidebar-1". 
  * made the default explicit

* Strict Standards: Declaration of Bootstrap_Walker_Nav_Menu::start_lvl() should be compatible with Walker_Nav_Menu::start_lvl(&$output, $depth = 0, $args = Array) in /var/www/flexpress/wordpress/wp-content/themes/Bootstrap-3-blank-wordpress-theme/functions.php on line 46 
 * made the declaration compatible, even though args is not used

* Notice: Undefined variable: class in /var/www/flexpress/wordpress/wp-content/themes/Bootstrap-3-blank-wordpress-theme/header.php on line 14 
  * added an isset check before using the variable